### PR TITLE
Fix 'ArgumentError' is not defined

### DIFF
--- a/smopy.py
+++ b/smopy.py
@@ -56,7 +56,7 @@ def fetch_map(box, z):
     y1 = min(2**z-1, y1)
     sx, sy = x1 - x0 + 1, y1 - y0 + 1
     if sx+sy >= MAXTILES:
-        raise ArgumentError(("You are requesting a very large map, beware of "
+        raise Exception(("You are requesting a very large map, beware of "
                  "OpenStreetMap tile usage policy "
                  "(http://wiki.openstreetmap.org/wiki/Tile_usage_policy)."))
     img = Image.new('RGB', (sx*TILE_SIZE, sy*TILE_SIZE))


### PR DESCRIPTION
To my knowledge, ArgumentError is not a standard python exception but comes from the module argparse. argparse.ArgumentError is for program arguments parsing, not for functions/methods arguments bad values.
In addition, the argparse module is not imported, thus when this line is executed, I get the error: "NameError: name 'ArgumentError' is not defined".

That is why I suggest to raise an Exception object.
