### PR TITLE
Bugfix: prevent margin operation from extending box beyond webmercator bounds.

### DIFF
--- a/smopy.py
+++ b/smopy.py
@@ -236,8 +236,12 @@ def extend_box(box_latlon, margin=.1):
     lon0, lon1 = min(lon0, lon1), max(lon0, lon1)
     dlat = max((lat1 - lat0) * margin, 0.0005)
     dlon = max((lon1 - lon0) * margin, 0.0005 / np.cos(np.radians(lat0)))
-    return (lat0 - dlat, lon0 - dlon,
-            lat1 + dlat, lon1 + dlon)
+    return (
+        max(lat0 - dlat, -80),
+        max(lon0 - dlon, -180),
+        min(lat1 + dlat, 80),
+        max(lon1 + dlon, 180),
+    )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The `extend_box` function could extend the coordinate box beyond webmercator bounds (lat: -80, 80, lon: -180, 180). The tileserver will respond with in-bounds tiles and `imshow` renders the map visually correct. However, `to_pixels` would calculate coordinates based on the out-of-bounds box and return values that do not correspond to the rendered image. Values returned by `extend_box` are now clipped to bounds so that this does not happen.

Example of bug:

```
coordinates = np.array([
    [51.0, 0.0],
    [50.0, 2.0]
])

fig, ax = plt.subplots()

map3 = smopy.Map((-50., -70., 30., 7.), z=2, maxtiles=10**2)
map3.show_mpl(ax=ax)
pixels = map3.to_pixels(coordinates)

plt.scatter(pixels[:, 0], pixels[:, 1], color="red")

plt.show()
```

![Schermafbeelding 2020-07-06 om 09 40 33](https://user-images.githubusercontent.com/9690/86569341-895b6f00-bf6e-11ea-97c1-bcdd63742d7e.png)
